### PR TITLE
Set `text_domain` to the default if it is not provided by the module

### DIFF
--- a/src/CirclicalTwigTrans/Factory/TransFactory.php
+++ b/src/CirclicalTwigTrans/Factory/TransFactory.php
@@ -43,6 +43,9 @@ class TransFactory implements FactoryInterface
         $config = $serviceLocator->get('config');
 
         foreach ($config['translator']['translation_file_patterns'] as $trcfg) {
+            if (!array_key_exists(self::DOMAIN, $trcfg)) {
+                $trcfg[self::DOMAIN] = 'default';
+            }
             bindtextdomain($trcfg[self::DOMAIN], realpath($trcfg['base_dir']) . '/');
             bind_textdomain_codeset($trcfg[self::DOMAIN], 'UTF-8');
         }

--- a/src/CirclicalTwigTrans/Factory/TransFactory.php
+++ b/src/CirclicalTwigTrans/Factory/TransFactory.php
@@ -37,6 +37,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 class TransFactory implements FactoryInterface
 {
     const DOMAIN = 'text_domain';
+    const DOMAIN_DEFAULT = 'default';
 
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
@@ -44,7 +45,7 @@ class TransFactory implements FactoryInterface
 
         foreach ($config['translator']['translation_file_patterns'] as $trcfg) {
             if (!array_key_exists(self::DOMAIN, $trcfg)) {
-                $trcfg[self::DOMAIN] = 'default';
+                $trcfg[self::DOMAIN] = self::DOMAIN_DEFAULT;
             }
             bindtextdomain($trcfg[self::DOMAIN], realpath($trcfg['base_dir']) . '/');
             bind_textdomain_codeset($trcfg[self::DOMAIN], 'UTF-8');


### PR DESCRIPTION
When using CirclicalTwigTrans with modules that are not aware of the `text_domain` property, a fatal error gets thrown. Since the translator definitions are appended to the config without a key, it's not possible to set the `text_domain` in local.php, etc. Therefore, the translator factory needs to set `text_domain` if it has not been set by the module, after which the code functions as expected.
